### PR TITLE
Fixed wiring error between adders

### DIFF
--- a/documentation/chisel-notes/first-hardware.md
+++ b/documentation/chisel-notes/first-hardware.md
@@ -135,7 +135,7 @@ val adder1 = Module(new SimpleAdder())
 val adder2 = Module(new SimpleAdder())
 
 adder2.io.inputx := adder1.io.result
-adder2.io.inputx := 3.U
+adder2.io.inputy := 3.U
 
 io.success := Mux(adder2.io.result === 128.U, true.B, false.B)
 ```


### PR DESCRIPTION
In the section for wiring the two adders together,  adder2 should have `inputy` set to `3.U` according to the text. Previously, it was wired to `inputx` which doesn't make sense considering that `inputx` is dedicated to the output of adder1.