### PR TITLE
Added note about reverse ordering of Fig 4.53 in text

### DIFF
--- a/assignments/assignment-3.md
+++ b/assignments/assignment-3.md
@@ -326,6 +326,8 @@ Specifically, Figure 4.53 will be helpful.
 Think about the conditions you want to forward and what you want to forward under each condition.
 `when/elsewhen/otherwise` statements will be useful here.
 
+Note: The entries for `ForwardA` and `ForwardB` in Figure 4.53 with values `10` and `01` should be *reversed* for our implementation (ex: `01` means the ALU operand is forwarded from the prior ALU result, NOT data memory)
+
 After this, you can remove the `forwarding.io := DontCare` from the top of the file.
 
 ## Testing your forwarding unit


### PR DESCRIPTION
Fig 4.53 in the Patterson & Hennessy textbook has the ordering of the signals that should be issued to the forwarding muxes *reversed*.

In our implementation we choose `01` to denote forward from the ALU result and `10` to denote forward from the memory stage but the textbook has this reversed. 

With permission from @powerjg I've added a note warning of this discrepancy.